### PR TITLE
Adding util class with getBowerDir to get the nearest bower directly, replacing the bower-directory dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,21 @@
 'use strict';
 
-var bowerDirectory = require('bower-directory');
 var path = require('path');
+var util = require('./util');
 
-var bowerDirCache;
-
-/**
- * This function returns the same value as `bowerDirectory.sync()`, but
- * caches it for future calls, instead of recalculating the bower directory
- * path each time like the original function does.
- * @return {string}
- */
-function getBowerDir() {
-  if (!bowerDirCache) {
-    bowerDirCache = bowerDirectory.sync();
-  }
-  return bowerDirCache;
-}
-
-function renameAlias(originalPath) {
+function renameAlias(originalPath, filename) {
   var result = originalPath;
   if (originalPath.substr(0, 6) === 'bower:') {
-    result = path.join(getBowerDir(), originalPath.substr(6));
+    var dir = util.getBowerDir();
+
+    // babel uses 'unknown' as a special value for filename when the transformed
+    // source can't be traced to a file (e.g., transformed string)
+    // https://github.com/babel/babel/blob/d2e7e6a/packages/babel-core/src/transformation/file/options/config.js
+    if (filename && filename !== 'unknown') {
+      dir = path.relative(path.dirname(filename), util.getBowerDir());
+    }
+
+    result = path.join(dir, originalPath.substr(6));
   }
   return result.replace(/\\/g, '/');
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-plugin-metal-register-components": "^1.0.0",
     "babel-plugin-transform-es2015-classes": "^6.2.2",
     "babel-preset-es2015": "^6.1.18",
-    "bower-directory": "^1.0.0"
+    "bower": "^1.7.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.0",

--- a/test/fixtures/bower-import.js
+++ b/test/fixtures/bower-import.js
@@ -1,0 +1,2 @@
+import foo from "bower:bar/src/foo";
+import bar from "bower:bar/src/bar";

--- a/test/test.js
+++ b/test/test.js
@@ -2,13 +2,18 @@
 
 var assert = require('assert');
 var babel = require('babel-core');
-var bowerDirectory = require('bower-directory');
+var util = require('../util');
 var preset = require('../index');
 var sinon = require('sinon');
 
 module.exports = {
+  testBowerDir: function(test) {
+    assert.strictEqual(util.getBowerDir({cwd: '/foo/bah'}), '/foo/bah/bower_components');
+    test.done();
+  },
+
   testBowerImport: function(test) {
-    sinon.stub(bowerDirectory, 'sync').returns('/path/to/bower');
+    sinon.stub(util, 'getBowerDir').returns('/path/to/bower');
     var code = 'import foo from "bower:bar/src/foo";\nimport bar from "bower:bar/src/bar";';
     var result = babel.transform(code, {presets: [preset]});
 
@@ -16,7 +21,19 @@ module.exports = {
     assert.notStrictEqual(-1, result.code.indexOf('/path/to/bower/bar/src/bar'));
     assert.strictEqual('/path/to/bower/bar/src/foo', result.metadata.modules.imports[0].source);
     assert.strictEqual('/path/to/bower/bar/src/bar', result.metadata.modules.imports[1].source);
-    bowerDirectory.sync.restore();
+    util.getBowerDir.restore();
+    test.done();
+  },
+
+  testBowerImportFromFile: function(test) {
+    sinon.stub(util, 'getBowerDir').returns(__dirname + '/bower');
+    var result = babel.transformFileSync(__dirname + '/fixtures/bower-import.js', {presets: [preset]});
+
+    assert.notStrictEqual(-1, result.code.indexOf('../bower/bar/src/foo'));
+    assert.notStrictEqual(-1, result.code.indexOf('../bower/bar/src/bar'));
+    assert.strictEqual('../bower/bar/src/foo', result.metadata.modules.imports[0].source);
+    assert.strictEqual('../bower/bar/src/bar', result.metadata.modules.imports[1].source);
+    util.getBowerDir.restore();
     test.done();
   },
 

--- a/util.js
+++ b/util.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var path = require('path');
+var bowerConfig = require('bower/lib/config');
+
+function getBowerDir(option) {
+  option = option || {};
+  option.cwd = option.cwd || process.cwd();
+
+  return path.resolve(option.cwd, bowerConfig(option).directory);
+}
+
+exports.getBowerDir = getBowerDir;


### PR DESCRIPTION
This fixes the flawed logic described in https://github.com/metal/gulp-metal/pull/6 (+cache w/o out of the box) and makes the renameAlias try to use a relative path (so the build works for, say, commonjs and others).
